### PR TITLE
chore: allow paths with spaces in perf-comp-local

### DIFF
--- a/scripts/perf-comp-local
+++ b/scripts/perf-comp-local
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-ROOT=$( cd $(dirname $0)/..;  pwd )
+ROOT=$( cd "$(dirname "$0")/.."; pwd )
 
 TMP_DIR=$(mktemp -d)
 echo "tmp dir: $TMP_DIR"


### PR DESCRIPTION
Otherwise, `$ROOT` would contain an invalid value when the project directory path contains spaces.