### PR TITLE
Fix test/dkg/ed25519/main.go generator.

### DIFF
--- a/test/dkg/ed25519/main.go
+++ b/test/dkg/ed25519/main.go
@@ -7,11 +7,15 @@
 package main
 
 import (
+	"crypto/rand"
 	"crypto/sha512"
 	"flag"
 	"fmt"
+	"log"
+	"math/big"
+
 	"github.com/coinbase/kryptology/pkg/core/curves"
-	"github.com/coinbase/kryptology/pkg/sharing/v1"
+	v1 "github.com/coinbase/kryptology/pkg/sharing/v1"
 
 	"filippo.io/edwards25519"
 	"github.com/coinbase/kryptology/internal"
@@ -199,11 +203,9 @@ func round3(participants map[uint32]*dkg.Participant, rnd2Bcast map[uint32]dkg.R
 
 func createDkgParticipants(thresh, limit int) map[uint32]*dkg.Participant {
 	curve := v1.Ed25519()
-	gx, gy := curve.Hash([]byte("Fair is foul, and foul is fair: Hover through the fog and filthy air."))
-	generator := &curves.EcPoint{
-		Curve: curve,
-		X:     gx,
-		Y:     gy,
+	generator, err := curves.NewScalarBaseMult(curve, getRandomBigInt())
+	if err != nil {
+		log.Fatalf("Failed to create generator: %v", err)
 	}
 	participants := make(map[uint32]*dkg.Participant, limit)
 	for i := 1; i <= limit; i++ {
@@ -223,6 +225,19 @@ func createDkgParticipants(thresh, limit int) map[uint32]*dkg.Participant {
 		participants[uint32(i)] = p
 	}
 	return participants
+}
+
+func getRandomBigInt() *big.Int {
+	// Max random value, a 130-bits integer, i.e 2^130 - 1
+	max := new(big.Int)
+	max.Exp(big.NewInt(2), big.NewInt(130), nil).Sub(max, big.NewInt(1))
+
+	//Generate cryptographically strong pseudo-random between 0 - max
+	n, err := rand.Int(rand.Reader, max)
+	if err != nil {
+		log.Fatalf("Failed to generate random number: %v", err)
+	}
+	return n
 }
 
 func printHelp() {


### PR DESCRIPTION
When creating a new DKG participant, the generator point
must lie on the Edward's curve and cannot be a random
point from a hardcoded test fixtures.

Tested with `go run test/dkg/ed25519/main.go` two commits
behind head due to https://github.com/coinbase/kryptology/issues/30.

type=routine
risk=low
impact=sev5
