### PR TITLE
Add PrependSign to BLS123-81 SigAug to enable signing with any pk prepended

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this repo will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v2.0.0
+## v2.1.0
+
+### Add
+
+- Added PrependSign to SigAug in BLS Signatures to allow prepending message with any public key.
 
 ### Add
 

--- a/pkg/signatures/bls/bls_sig/usual_bls.go
+++ b/pkg/signatures/bls/bls_sig/usual_bls.go
@@ -237,6 +237,20 @@ func (b SigAug) PartialSign(sks *SecretKeyShare, pk *PublicKey, msg []byte) (*Pa
 	return sks.partialSign(bytes, b.dst)
 }
 
+// Computes a signature in G1 with a prepended public key that is not necessary derived from the secret key
+func (b SigAug) PrependSign(sk *SecretKey, msg []byte, pk *PublicKey) (*Signature, error) {
+	if len(msg) == 0 {
+		return nil, fmt.Errorf("message cannot be empty or nil")
+	}
+
+	bytes, err := pk.MarshalBinary()
+	if err != nil {
+		return nil, fmt.Errorf("MarshalBinary failed")
+	}
+	bytes = append(bytes, msg...)
+	return sk.createSignature(bytes, b.dst)
+}
+
 // CombineSignatures takes partial signatures to yield a completed signature
 func (b SigAug) CombineSignatures(sigs ...*PartialSignature) (*Signature, error) {
 	return combineSigs(sigs)


### PR DESCRIPTION
type=feature
risk=low
impact=sev2

Hi, I'm implementing the Signer interface for BLS123-81 in Rosetta SDK and require the ability to sign with a public key that is not derived from the secret key.

I felt it would be cleaner/safer to add this new exported function instead of introducing a breaking change to Sign which currently derives a public key from the passed in secret key.
