### PR TITLE
fix: make schnorr zkp work with all curves

### DIFF
--- a/pkg/zkp/schnorr/schnorr_test.go
+++ b/pkg/zkp/schnorr/schnorr_test.go
@@ -15,13 +15,12 @@ func TestZKPOverMultipleCurves(t *testing.T) {
 	curveInstances := []*curves.Curve{
 		curves.K256(),
 		curves.P256(),
-		// TODO: the code fails on the following curves. Investigate if this is expected.
-		// curves.PALLAS(),
-		// curves.BLS12377G1(),
-		// curves.BLS12377G2(),
-		// curves.BLS12381G1(),
-		// curves.BLS12381G2(),
-		// curves.ED25519(),
+		curves.PALLAS(),
+		curves.BLS12377G1(),
+		curves.BLS12377G2(),
+		curves.BLS12381G1(),
+		curves.BLS12381G2(),
+		curves.ED25519(),
 	}
 	for i, curve := range curveInstances {
 		uniqueSessionId := sha3.New256().Sum([]byte("random seed"))


### PR DESCRIPTION
Now schnorr zkp works only with curves that are defined over fields of 256 bits since C is generated using SetBytes() on a hash of 256 bits.
This PR fixes it by using Scalar.Hash instead (doesn't rely on the size of the field).

type=routine
risk=low
impact=sev5
