### PR TITLE
public Xij DkgRound2P2PSend

### DIFF
--- a/pkg/tecdsa/gg20/participant/dkg_round2.go
+++ b/pkg/tecdsa/gg20/participant/dkg_round2.go
@@ -24,7 +24,7 @@ type DkgRound2Bcast struct {
 
 // DkgRound2P2PSend contains value that will be P2PSend to all other player Pj
 type DkgRound2P2PSend struct {
-	xij *v1.ShamirShare
+	Xij *v1.ShamirShare
 }
 
 // DkgRound2 implements distributed key generation round 2
@@ -103,12 +103,12 @@ func (dp *DkgParticipant) DkgRound2(params map[uint32]*DkgRound1Bcast) (*DkgRoun
 			return nil, nil, err
 		}
 
-		// P2PSend xij to player Pj
+		// P2PSend Xij to player Pj
 		if dp.state.X == nil || dp.state.X[id-1] == nil {
 			return nil, nil, fmt.Errorf("Missing Shamir share to P2P send")
 		}
 		p2PSend[id] = &DkgRound2P2PSend{
-			xij: dp.state.X[id-1],
+			Xij: dp.state.X[id-1],
 		}
 
 		// Store other parties data

--- a/pkg/tecdsa/gg20/participant/dkg_rounds_test.go
+++ b/pkg/tecdsa/gg20/participant/dkg_rounds_test.go
@@ -942,23 +942,23 @@ func TestDkgFullRoundsWorks(t *testing.T) {
 	decommitments[3] = dkgR2Bcast[3].Di
 
 	dkgR3Out[1], err = dkgParticipants[1].DkgRound3(decommitments, map[uint32]*v1.ShamirShare{
-		1: dkgParticipants[1].state.X[0],
-		2: dkgParticipants[2].state.X[0],
-		3: dkgParticipants[3].state.X[0],
+		1: nil,
+		2: dkgR2P2PSend[2][1].Xij,
+		3: dkgR2P2PSend[3][1].Xij,
 	})
 	require.NoError(t, err)
 
 	dkgR3Out[2], err = dkgParticipants[2].DkgRound3(decommitments, map[uint32]*v1.ShamirShare{
-		1: dkgParticipants[1].state.X[1],
-		2: dkgParticipants[2].state.X[1],
-		3: dkgParticipants[3].state.X[1],
+		1: dkgR2P2PSend[1][2].Xij,
+		2: nil,
+		3: dkgR2P2PSend[3][2].Xij,
 	})
 	require.NoError(t, err)
 
 	dkgR3Out[3], err = dkgParticipants[3].DkgRound3(decommitments, map[uint32]*v1.ShamirShare{
-		1: dkgParticipants[1].state.X[2],
-		2: dkgParticipants[2].state.X[2],
-		3: dkgParticipants[3].state.X[2],
+		1: dkgR2P2PSend[1][3].Xij,
+		2: dkgR2P2PSend[2][3].Xij,
+		3: nil,
 	})
 	require.NoError(t, err)
 

--- a/pkg/tecdsa/gg20/participant/participant.go
+++ b/pkg/tecdsa/gg20/participant/participant.go
@@ -236,7 +236,7 @@ func (p Participant) convertToAdditive(curve elliptic.Curve, publicSharesMap map
 	return &Signer{
 		sk:              p.sk,
 		share:           privateKeyShare,
-		publicSharesMap: additiveMap,
+		publicSharesMap: publicSharesMap,
 		Round:           1,
 		state:           &state{},
 	}, nil

--- a/pkg/tecdsa/gg20/participant/participant.go
+++ b/pkg/tecdsa/gg20/participant/participant.go
@@ -295,11 +295,15 @@ func makeXMap(curve elliptic.Curve, publicSharesMap map[uint32]*dealer.PublicSha
 	return x, nil
 }
 
-func NewDkgParticipant(curve elliptic.Curve, id uint32, round uint) *DkgParticipant {
+func NewDkgParticipant(curve elliptic.Curve, id, total, threshold uint32, round uint) *DkgParticipant {
 	return &DkgParticipant{
 		Curve: curve,
 		id:    id,
 		Round: round,
+		state: &dkgstate{
+			Threshold: threshold,
+			Limit:     total,
+		},
 	}
 }
 

--- a/pkg/tecdsa/gg20/participant/participant.go
+++ b/pkg/tecdsa/gg20/participant/participant.go
@@ -236,7 +236,7 @@ func (p Participant) convertToAdditive(curve elliptic.Curve, publicSharesMap map
 	return &Signer{
 		sk:              p.sk,
 		share:           privateKeyShare,
-		publicSharesMap: publicSharesMap,
+		publicSharesMap: additiveMap,
 		Round:           1,
 		state:           &state{},
 	}, nil

--- a/pkg/tecdsa/gg20/participant/participant.go
+++ b/pkg/tecdsa/gg20/participant/participant.go
@@ -295,6 +295,14 @@ func makeXMap(curve elliptic.Curve, publicSharesMap map[uint32]*dealer.PublicSha
 	return x, nil
 }
 
+func NewDkgParticipant(curve elliptic.Curve, id uint32, round uint) *DkgParticipant {
+	return &DkgParticipant{
+		Curve: curve,
+		id:    id,
+		Round: round,
+	}
+}
+
 // DkgParticipant is a DKG player that contains information needed to perform DKG rounds and finally get info for signing rounds.
 type DkgParticipant struct {
 	Curve elliptic.Curve


### PR DESCRIPTION
To be able to use a p2p message, you need to make the field public. Based on the use of ShamirShare in the gennaro package, this change appears to be safe.

type=routine
risk=low
impact=sev5
