### PR TITLE
Removing redundant operations in EdDSA package

### DIFF
--- a/pkg/ted25519/ted25519/ed25519.go
+++ b/pkg/ted25519/ted25519/ed25519.go
@@ -121,9 +121,6 @@ func newKeyFromSeed(privateKey, seed []byte) error {
 	}
 
 	digest := sha512.Sum512(seed)
-	digest[0] &= 248
-	digest[31] &= 127
-	digest[31] |= 64
 
 	var hBytes [32]byte
 	copy(hBytes[:], digest[:])


### PR DESCRIPTION
type=routine
risk=low
impact=sev5

The bytes operations defined in the standard have been implemented in the SetBytesClamping function. So these in the function newKeyFromSeed are redundent. 